### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish Linux
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BASE_CONTAINER: ubuntu:bionic-20200630
         with:
@@ -24,7 +24,7 @@ jobs:
           tags: "latest"
 
       - name: Publish Python
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BASE_CONTAINER: dblodgett/hydrogeoenv-linux
         with:
@@ -37,7 +37,7 @@ jobs:
           tags: "latest"
 
       - name: Publish R
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BASE_CONTAINER: dblodgett/hydrogeoenv-python
         with:
@@ -50,7 +50,7 @@ jobs:
           tags: "latest"
 
       - name: Publish Custom
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BASE_CONTAINER: dblodgett/hydrogeoenv-r
         with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore